### PR TITLE
Fix character selection

### DIFF
--- a/godot/src/UI/Menus/Characters/CharacterList.gd
+++ b/godot/src/UI/Menus/Characters/CharacterList.gd
@@ -62,6 +62,11 @@ func get_character_data(index: int) -> Dictionary:
 	return {name = listing.label.text, color = listing.texture.modulate}
 
 
+# Returns the selected characterData. Convenience function for `get_character_data`
+func get_selected_character() -> Dictionary:
+	return get_character_data(selected_index)
+
+
 func _on_CharacterListing_requested_deletion(index: int) -> void:
 	emit_signal("requested_deletion", index)
 


### PR DESCRIPTION
The method `get_selected_character` that was called didn't exist. `get_selected_character` was added as a convenience function for `get_character_data`.

The problem occurred in the character selection dialog after re-login.

This solution was implemented instead of changing this function call:
https://github.com/heroiclabs/nakama-godot-demo/blob/d8cbb6954121a28458ce5e01f216ebd589f3f27f/godot/src/UI/Menus/Characters/CharacterSelector.gd#L38
to provide a convenience function so the index does not have to be retrieved from the class to which it's passed on function call.